### PR TITLE
Updated the supervisord process to use `/run/supervisord.pid` for the PID file location.

### DIFF
--- a/deploy/inc/entrypoint.sh
+++ b/deploy/inc/entrypoint.sh
@@ -173,4 +173,4 @@ if [ "$KEA_DB_TYPE" == "postgresql" ]; then
 fi
 
 # Start the main supervisord process that spawns Kea services
-supervisord -c /etc/supervisor/supervisord.conf
+supervisord -j /run/supervisord.pid -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
### closes: #1 

Updating the supervisord execution in the `entrypoint.sh` script to use the `-j` argument for the PID file path. The new location of the PID will be `/run/supervisord.pid`.